### PR TITLE
feat(npm): bump manifest ranges so package.json and the lockfile update together

### DIFF
--- a/default.json
+++ b/default.json
@@ -15,5 +15,12 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["every weekend"]
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Bump the manifest range (package.json), not just the lockfile, so both update together. npm's default rangeStrategy ('replace') leaves a caret range untouched when the new version still satisfies it, so in-range minor/patch updates would otherwise only change the lockfile.",
+      "matchManagers": ["npm"],
+      "rangeStrategy": "bump"
+    }
+  ]
 }


### PR DESCRIPTION
## What

Set `rangeStrategy: "bump"` for the **npm** manager in the shared preset, so an in-range dependency update bumps the `package.json` range *and* the lockfile in the same PR — instead of only touching the lockfile.

## Why

npm's default `rangeStrategy` is `replace`: it only rewrites a range in `package.json` when the new version falls **outside** it. With caret ranges (`"simple-icons": "^16.22.0"`), a `16.22.0 → 16.23.0` bump still satisfies `^16.22.0`, so Renovate leaves `package.json` alone and updates `package-lock.json` only. The manifest then drifts behind the lockfile until the next *major*.

`bump` rewrites the floor (`^16.22.0 → ^16.23.0`) alongside the lockfile, keeping the manifest honest about the minimum version actually in use. Appropriate here: these are self-hosted **apps**, not published libraries, so no downstream consumer depends on our declared ranges.

Scoped to `matchManagers: ["npm"]` deliberately — that's where caret ranges live. `gomod` (go.mod), Docker tags, Helm chart versions, and the digest-pinned GitHub Actions all already pin exact versions, so they're unaffected.

## Validation

- `renovate-config-validator default.json` → *Config validated successfully*.
- Valid JSON; presets resolve.

## Effect

Every repo extending `local>home-operations/renovate-config` (konflate's UI, and any future npm manifests) will get manifest+lockfile bumps together. No change to non-npm ecosystems. The first in-range npm update after this merges will demonstrate it (e.g. a future simple-icons bump editing `package.json` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
