### PR TITLE
ci: add the annotated-dependencies regex manager to the shared config

### DIFF
--- a/annotated.json5
+++ b/annotated.json5
@@ -1,0 +1,26 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Process annotated dependencies",
+      managerFilePatterns: ["/\\.env(?:\\.j2)?$/", "/\\.sh(?:\\.j2)?$/", "/\\.yaml(?:\\.j2)?$/"],
+      matchStrings: [
+        // # renovate: datasource=github-releases depName=foo/bar
+        // foobar_version: v1.0.0
+        // # renovate: datasource=github-releases depName=foo/bar
+        // foobar_version: "v1.0.0"
+        // # renovate: datasource=github-releases depName=foo/bar
+        // foobar_version: &version v1.0.0
+        // # renovate: datasource=github-releases depName=foo/bar
+        // foobar_version: &version "v1.0.0"
+        // # renovate: datasource=docker depName=ghcr.io/foo/bar
+        // FOOBAR_VERSION=v1.0.0
+        // # renovate: datasource=docker depName=ghcr.io/foo/bar
+        // FOOBAR_VERSION="v1.0.0"
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+(:\\s|=)(&\\S+\\s)?[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
+      ],
+      datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+    },
+  ],
+}

--- a/default.json
+++ b/default.json
@@ -4,6 +4,7 @@
     "config:recommended",
     "docker:enableMajor",
     "helpers:pinGitHubActionDigestsToSemver",
+    "github>home-operations/renovate-config:annotated.json5",
     "github>home-operations/renovate-config:autoMerge.json5",
     "github>home-operations/renovate-config:labels.json5",
     "github>home-operations/renovate-config:semanticCommits.json5",


### PR DESCRIPTION
Adds the `# renovate:` annotation manager to the **shared** config so every repo that extends `local>home-operations/renovate-config` gets it automatically — instead of each repo wiring it itself.

- New `annotated.json5` — a `customManager` (regex) that processes `# renovate: datasource=… depName=…` comments in `.env` / `.sh` / `.yaml` files (the same rule that lives in `renovate-presets`).
- `default.json` extends it alongside the other presets.

## What this turns on

- **Chart repos** (konflate, kromgo, tuppr): the annotated `HELM_UNITTEST_VERSION` workflow env (PRs konflate#69, kromgo#231, tuppr#315) becomes Renovate-managed.
- **`.github`**: the `helm-docs` / `helm-schema` pins in `renovate-entrypoint.sh` (added in #14) become Renovate-managed.

Supersedes the closed home-operations/.github#16 (which had put the manager only in the `.github` repo).

> No version-pin/extends changes are needed in the consuming repos — they already extend `renovate-config`, so they pick this up automatically once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
