### PR TITLE
fix: don't mark major CI/tooling bumps as breaking

### DIFF
--- a/semanticCommits.json5
+++ b/semanticCommits.json5
@@ -32,23 +32,31 @@
       semanticCommitScope: "helm",
       commitMessageTopic: "chart {{depName}}",
     },
+    // github-actions, github-releases, and mise are CI/build tooling, not the
+    // released image/chart, so a major bump of them must not count as a breaking
+    // change: override the major-update `!:` prefix (set above) with a plain `:`,
+    // so release-please never cuts a version bump from a `ci!`/`chore!` tooling
+    // update (a `ci`/`chore` type is non-releasing on its own; only the `!` bumps).
     {
       matchManagers: ["github-actions"],
       semanticCommitType: "ci",
       semanticCommitScope: "github-action",
       commitMessageTopic: "action {{depName}}",
+      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}}):",
     },
     {
       matchDatasources: ["github-releases"],
       semanticCommitType: "chore",
       semanticCommitScope: "github-release",
       commitMessageTopic: "release {{depName}}",
+      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}}):",
     },
     {
       matchManagers: ["mise"],
       semanticCommitType: "chore",
       semanticCommitScope: "mise",
       commitMessageTopic: "tool {{depName}}",
+      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}}):",
     },
   ],
 }


### PR DESCRIPTION
## Problem

`semanticCommits.json5` applies a breaking `!:` prefix to **all** major updates:

```json5
{ matchUpdateTypes: ["major"],
  commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}})!:" }
```

The github-actions / github-releases / mise rules run later and override the
*type* (to `ci`/`chore`) but not the prefix, so a major tooling bump renders as
**`ci(github-action)!:`** / `chore(github-release)!:` / `chore(mise)!:`.

release-please treats the `!` as a breaking change and cuts a release (a minor
bump pre-1.0) — for a CI action or dev-tool update that doesn't touch the shipped
image/chart at all. This is live across the org: tuppr's CHANGELOG, for example,
has multiple releases whose only "⚠ BREAKING CHANGES" entry is a `github-action`
bump (`release-please-action v4→v5`, `azure/setup-helm v4→v5`,
`docker/build-push-action v6→v7`, …).

## Fix

Give the three tooling rules a `commitMessagePrefix` without the `!` (they run
after the major rule, so they win):

```json5
commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}}):"
```

A major tooling bump now renders `ci(github-action): …` / `chore(mise): …`, which
is non-breaking — and `ci`/`chore` don't trigger a release on their own. Runtime
dependencies (docker, helm, npm) keep `!` on majors, since those *do* change the
released artifact.

There's no release-please-side knob for this — a `!`/`BREAKING CHANGE` bumps
regardless of type, so it has to be fixed here, at the commit source.

Validated with `renovate-config-validator --strict`.
