### PR TITLE
feat(automerge): auto-merge Renovate itself (npm:renovate)

### DIFF
--- a/autoMerge.json5
+++ b/autoMerge.json5
@@ -26,5 +26,15 @@
       minimumReleaseAge: "1 minute",
       ignoreTests: true,
     },
+    {
+      description: "Auto-merge Renovate itself (npm:renovate)",
+      matchDatasources: ["npm"],
+      matchPackageNames: ["renovate"],
+      automerge: true,
+      automergeType: "branch",
+      matchUpdateTypes: ["minor", "patch"],
+      minimumReleaseAge: "1 minute",
+      ignoreTests: true,
+    },
   ],
 }


### PR DESCRIPTION
Enables automerge for Renovate's own self-updates (the `npm:renovate` mise tool pin), which currently sit as open PRs (e.g. #19).

Adds a third rule to `autoMerge.json5` matching the `renovate` npm package:
```json5
{
  matchDatasources: ["npm"],
  matchPackageNames: ["renovate"],
  automerge: true,
  automergeType: "branch",
  matchUpdateTypes: ["minor", "patch"],
  minimumReleaseAge: "1 minute",
  ignoreTests: true,
}
```
- Mirrors the existing trusted-source pattern (the `renovatebot/*` GitHub-Actions rule).
- **minor/patch only** — a major Renovate bump still gets manual review (config-schema breakage risk).
- Validated with `renovate-config-validator --strict` (3 files OK).

Since `default.json` extends `autoMerge.json5`, this applies wherever `renovate` is pinned; in practice that's this repo's mise tool. After merge, Renovate's next run should auto-merge #19.