### PR TITLE
style: indent markdown at 2 to match embedded yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = false
 
 [Dockerfile]


### PR DESCRIPTION
Mirrors the canonical change in home-operations/.github#37.

This repo was skipped in the first rollout because its markdown was already 2-space, so no file reformats. But the editorconfig still said `[*.md] indent_size = 4`, which under the shared oxfmt pre-commit hook would reindent embedded yaml to 4 spaces on the next markdown edit, reintroducing the bug fixed across the org. This flips it to 2 for consistency; no files change.