### PR TITLE
feat: scope dependency commits by ecosystem (go/rust/npm)

### DIFF
--- a/semanticCommits.json5
+++ b/semanticCommits.json5
@@ -32,6 +32,21 @@
       semanticCommitScope: "helm",
       commitMessageTopic: "chart {{depName}}",
     },
+    {
+      matchManagers: ["gomod"],
+      semanticCommitScope: "go",
+      commitMessageTopic: "module {{depName}}",
+    },
+    {
+      matchManagers: ["cargo"],
+      semanticCommitScope: "rust",
+      commitMessageTopic: "crate {{depName}}",
+    },
+    {
+      matchManagers: ["npm"],
+      semanticCommitScope: "npm",
+      commitMessageTopic: "dependency {{depName}}",
+    },
     // github-actions, github-releases, and mise are CI/build tooling, not the
     // released image/chart, so a major bump of them must not count as a breaking
     // change: override the major-update `!:` prefix (set above) with a plain `:`,


### PR DESCRIPTION
Follow-up to #37. Reviewing ~386 merged Renovate PRs across the org showed 137 collapsing into a single `deps` scope, mixing three distinct ecosystems:

| Manager | Was | Now |
|---|---|---|
| `gomod` | `fix(deps): update module golang.org/x/text` | `fix(go): update module golang.org/x/text` |
| `cargo` | `feat(deps): update rust crate tokio` | `feat(rust): update crate tokio` |
| `npm` | `fix(deps): update dependency svelte` | `fix(npm): update dependency svelte` |

Mirrors the existing manager-based scopes (`container`, `helm`, `github-action`, `mise`).

**Only the scope changes** — `semanticCommitType` and the breaking-change `!` logic are untouched, so a major bump still emits `feat(go)!:` and correctly triggers a release-please version bump (unlike the `mise`/`github-*` tooling rules, which intentionally suppress the `!`). Anything unmatched (e.g. `lock file maintenance`) stays `chore(deps)`.

## Validation

`renovate-config-validator --strict` and `oxfmt` pass (also via pre-commit hooks).