### PR TITLE
fix: raise a pull request before automerging

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,7 @@
     "github>home-operations/renovate-config:helmPostUpgradeTasks.json5",
     "github>home-operations/renovate-config:labels.json5",
     "github>home-operations/renovate-config:semanticCommits.json5",
-    ":automergeBranch",
+    ":automergePr",
     ":configMigration",
     ":dependencyDashboard",
     ":disableRateLimiting"


### PR DESCRIPTION
## Overview

Swaps `:automergeBranch` for `:automergePr` in the shared default.

## Additional information

`:automergeBranch` is `{"automergeType": "branch"}` — when a rule sets
`automerge: true`, Renovate pushes the commit straight to the base branch with
**no pull request**. That is how `ci(github-action): Update action …` commits
landed on `main` unreviewed across the org, until the `autoMerge` preset holding
those rules was dropped in 4b32c37.

Nothing extending this repo sets `automerge: true` today, so the preset is inert
right now. But it is the default every repo inherits, so the next packageRule
that enables automerge would silently push to main again. `:automergePr` is
`{"automergeType": "pr"}` — Renovate raises a PR first and merges that.

Worth noting CI in these repos only runs on `pull_request` and pushes to `main`,
so a Renovate branch has no status checks for branch automerge to gate on
regardless.

Once this lands, the `automergeType: "pr"` overrides in `containers`,
`charts-mirror` and `k8s-schemas` become redundant and can be removed — I am
holding those PRs until this merges, so there is no window where a repo has
`automerge: true` while still inheriting branch automerge.

Validated with `renovate-config-validator --strict` against all 6 files.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — change and description written by an AI agent (Claude Code) under maintainer direction.