### PR TITLE
chore(mise): drop the gen task that references a missing script

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -13,10 +13,6 @@ oxfmt = "0.60.0"
 shellcheck = "0.11.0"
 zizmor = "1.28.0"
 
-[tasks.gen]
-description = "Regenerate default.json from the preset directories"
-run = "node scripts/gen-default.mjs"
-
 [tasks."lint"]
 description = "Check JSON/JSON5, YAML, Markdown, and shell formatting"
 run = [


### PR DESCRIPTION
## Overview

`[tasks.gen]` runs `node scripts/gen-default.mjs`, but this repo has no
`scripts/` directory — `mise run gen` has always failed here.

It looks copied from home-operations/renovate-presets, where `default.json` genuinely is
generated by walking `config/`, `managers/`, `overrides/`, `policies/` and
`versioning/`.

This repo's `default.json` is hand-written: it lists sibling presets by name
(`github>home-operations/renovate-config:groups.json5`) with no subdirectories, so
there is nothing to generate.

The `node` tool pin stays — `npm:renovate` needs it to run
`renovate-config-validator`.

`mise tasks` now lists just `lint` and `validate`, both of which still pass.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — change and description written by an AI agent (Claude Code) under maintainer direction.