### PR TITLE
ci(github-action): update workflow-lint action (1.0.0 → v1.0.2)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
           echo "zizmor=$(mise config get tools.zizmor)" >> "$GITHUB_OUTPUT"
 
       - name: Lint workflows
-        uses: home-operations/.github/actions/workflow-lint@dfa0b198336d33dcbe73557a68315d3071ec7709 # workflow-lint-1.0.0
+        uses: home-operations/.github/actions/workflow-lint@5514ee499e8919d394b5376637025535dac84ff8 # workflow-lint-v1.0.2
         with:
           actionlint-version: ${{ steps.tools.outputs.actionlint }}
           zizmor-version: ${{ steps.tools.outputs.zizmor }}


### PR DESCRIPTION
Bump `home-operations/.github/actions/workflow-lint` from 1.0.0 to v1.0.2.

v1.0.1 pins tool versions and v1.0.2 makes actionlint ignore its false errors on GitHub's new `$/` self-repository `uses:` syntax, so workflows adopting `$/` lint clean.