### PR TITLE
feat: add custom manager for the shared .github action pins

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,6 +10,7 @@
     "github>home-operations/renovate-config:helmPostUpgradeTasks.json5",
     "github>home-operations/renovate-config:labels.json5",
     "github>home-operations/renovate-config:semanticCommits.json5",
+    "github>home-operations/renovate-config:sharedActions.json5",
     ":automergePr",
     ":configMigration",
     ":dependencyDashboard",

--- a/sharedActions.json5
+++ b/sharedActions.json5
@@ -1,0 +1,38 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  customManagers: [
+    {
+      // The github-actions manager cannot update these pins: both actions
+      // resolve to the same depName (home-operations/.github), and the pin
+      // comment (`workflow-lint-v1.0.2`) is not version-like, so extraction
+      // falls back to the github-digest datasource with exact versioning and
+      // no update is ever found. This manager keys the lookup on the action
+      // path instead and filters the repo's per-action prefixed tags via
+      // extractVersion.
+      description: "Update home-operations/.github shared action pins (per-action prefixed tags)",
+      customType: "regex",
+      managerFilePatterns: ["/\\.github/workflows/[^/]+\\.ya?ml$/"],
+      matchStrings: [
+        "uses: home-operations/\\.github/actions/(?<action>[\\w-]+)@(?<currentDigest>[a-f0-9]{40})\\s+#\\s+[\\w-]+-(?<currentValue>v?\\d+\\.\\d+\\.\\d+)",
+      ],
+      depNameTemplate: "home-operations/.github/actions/{{{action}}}",
+      packageNameTemplate: "home-operations/.github",
+      datasourceTemplate: "github-tags",
+      extractVersionTemplate: "^{{{action}}}-(?<version>v?\\d+\\.\\d+\\.\\d+)$",
+      versioningTemplate: "semver-coerced",
+    },
+  ],
+  packageRules: [
+    {
+      // Match the github-actions manager's conventions from groups.json5 and
+      // semanticCommits.json5 so these PRs look like every other action bump.
+      matchManagers: ["custom.regex"],
+      matchPackageNames: ["home-operations/.github"],
+      groupName: "github-actions",
+      semanticCommitType: "ci",
+      semanticCommitScope: "github-action",
+      commitMessageTopic: "action {{depName}}",
+      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}}):",
+    },
+  ],
+}


### PR DESCRIPTION
Renovate has never updated the `home-operations/.github/actions/workflow-lint` / `docs-build` pins (today's 1.0.0 → v1.0.2 sweep was manual). Root cause, from the github-actions manager source: the pin comment (`# workflow-lint-v1.0.2`) is extracted as `currentValue`, but it fails Renovate's `versionLikeRe` (`^v?\d+`), so the dep falls back to the github-digest datasource with `exact` versioning - no update is ever found. And since both actions extract the same `depName`/`packageName` (`home-operations/.github`), a plain `packageRules` entry cannot fix it (datasource is not overridable there, and the two actions' tag prefixes differ).

This adds a `sharedActions.json5` preset with a regex custom manager that keys the lookup on the action path, uses `github-tags` with `extractVersionTemplate: ^{{action}}-(?<version>...)$` per action, and `semver-coerced` to tolerate the older bare-`1.0.0` tags. A packageRule mirrors the `ci(github-action):` semantic-commit and `github-actions` group conventions.

Verified with `renovate-config-validator --strict` (all presets pass) and a `--platform=local --dry-run=lookup` run against a workflow pinning `workflow-lint-v1.0.2` + `docs-build-v1.0.1`: it proposes exactly `workflow-lint v1.0.2 → v1.0.3` with the correct tag digest `69cad1e`, and leaves docs-build (already latest) alone.