### PR TITLE
feat: delay mise tool updates until releases are 3 days old

### DIFF
--- a/groups.json5
+++ b/groups.json5
@@ -15,6 +15,11 @@
       matchManagers: ["mise"],
       groupName: "mise tools",
       groupSlug: "mise-tools",
+      // Same window as the GitHub Actions group above. Fresh releases often
+      // finish uploading per-arch assets and attestations after the tag
+      // appears; locking too early is how mise.lock ends up with missing
+      // platform URLs.
+      minimumReleaseAge: "3 days",
     },
     {
       description: "Go Toolchain Group",


### PR DESCRIPTION
Adds `minimumReleaseAge: "3 days"` to the Mise Tools Group, matching the GitHub Actions group. Renovate's mise.lock artifact update silently drops platform `url`/`url_api` entries when asset lookups fail - the zizmor 1.29.0 bump did exactly that in tuppr, external-dns-unifi-webhook, and gatus-sidecar because the bump PRs raced the release's asset/attestation uploads. Waiting out the upload window removes the most common trigger. The global `minimumReleaseAgeBehaviour: "timestamp-optional"` already handles datasources without timestamps.

The go/rust/node toolchain rules below only override `groupName`/`groupSlug`, so the age also applies to toolchain bumps - same as it would for any other mise dep.