### PR TITLE
fix: track Go patch releases in the go.mod go directive

### DIFF
--- a/groups.json5
+++ b/groups.json5
@@ -30,6 +30,20 @@
       groupSlug: "go-toolchain",
     },
     {
+      // The go directive defaults to Renovate's go-mod-directive versioning,
+      // which reads `go 1.26.4` as a minimum satisfied by any later 1.26.x —
+      // so Renovate proposes directive updates only on new minors and the
+      // directive drifts behind the mise-pinned toolchain on every patch
+      // (the fleet sat at 1.26.0–1.26.4 while mise was on 1.26.5). Semver
+      // versioning makes patches count as updates; the group above then
+      // lands the directive bump in the same PR as the mise pin.
+      description: "Track Go patch releases in go.mod's go directive",
+      matchManagers: ["gomod"],
+      matchDepNames: ["go"],
+      matchDepTypes: ["golang"],
+      versioning: "semver",
+    },
+    {
       description: "Rust Toolchain Group",
       matchManagers: ["mise"],
       matchDepNames: ["rust"],


### PR DESCRIPTION
Answers "why is Renovate ignoring go.mod's go version": the go directive dep uses Renovate's `go-mod-directive` versioning, which treats `go 1.26.4` as a *minimum* satisfied by any later 1.26.x - so only new minors ever produce an update and the directive drifts behind the mise-pinned toolchain on every patch. The fleet currently sits at `go 1.26.0` (kromgo) through `1.26.4` while mise pins 1.26.5 everywhere.

This overrides the versioning to `semver` for the gomod `go` dep (depType `golang`), making patch releases count as updates. The existing Go Toolchain Group already matches both the mise pin and the directive, so both land in one grouped PR.

Verified with a `--platform=local --dry-run=lookup` run against a `go 1.26.0` go.mod: without the rule no update is found; with it Renovate proposes exactly `1.26.5` as a `patch` update.

Not security-critical (govulncheck keys stdlib findings off the running toolchain, which mise pins current - downflate was the one repo where the toolchain itself was stale, fixed in its govulncheck PR), but the drift means the declared language version lags what actually builds.