### PR TITLE
feat: treat 0.x minor updates as breaking

### DIFF
--- a/groups.json5
+++ b/groups.json5
@@ -59,5 +59,19 @@
       groupName: "Node toolchain",
       groupSlug: "node-toolchain",
     },
+    {
+      // Renovate splits grouped majors onto a major-<groupSlug> branch, but
+      // that split is keyed on updateType, so 0.x minors — breaking per
+      // SemVer, see labels.json5/semanticCommits.json5 — would ride the safe
+      // non-major group branch (and its automerge rules). The default
+      // branchName template is {{branchPrefix}}{{additionalBranchPrefix}}
+      // {{branchTopic}}, so prefixing here lands them on the same
+      // major-<groupSlug> branch as real majors; ungrouped deps just get a
+      // major- branch rename.
+      description: "Route 0.x minor updates onto the major branches",
+      matchUpdateTypes: ["minor"],
+      matchCurrentVersion: "/^v?0\\./",
+      additionalBranchPrefix: "major-",
+    },
   ],
 }

--- a/groups.json5
+++ b/groups.json5
@@ -59,16 +59,10 @@
       groupName: "Node toolchain",
       groupSlug: "node-toolchain",
     },
+    // The branch prefix lands these on the same major-<groupSlug> branch
+    // Renovate uses to split grouped majors, instead of the safe group PR.
     {
-      // Renovate splits grouped majors onto a major-<groupSlug> branch, but
-      // that split is keyed on updateType, so 0.x minors — breaking per
-      // SemVer, see labels.json5/semanticCommits.json5 — would ride the safe
-      // non-major group branch (and its automerge rules). The default
-      // branchName template is {{branchPrefix}}{{additionalBranchPrefix}}
-      // {{branchTopic}}, so prefixing here lands them on the same
-      // major-<groupSlug> branch as real majors; ungrouped deps just get a
-      // major- branch rename.
-      description: "Route 0.x minor updates onto the major branches",
+      description: "zer0ver: 0.x minors can break at any time, route them onto the major branches",
       matchUpdateTypes: ["minor"],
       matchCurrentVersion: "/^v?0\\./",
       additionalBranchPrefix: "major-",

--- a/labels.json5
+++ b/labels.json5
@@ -9,10 +9,9 @@
       matchUpdateTypes: ["minor"],
       labels: ["type/minor"],
     },
-    // Renovate classifies 0.x → 0.y as minor, but SemVer gives pre-1.0.0
-    // releases no stability guarantee, so label them as majors instead
-    // (later rules win, overriding the type/minor rule above).
+    // Keep below the plain minor rule so this one wins for 0.x.
     {
+      description: "zer0ver: 0.x minors can break at any time, label them as majors",
       matchUpdateTypes: ["minor"],
       matchCurrentVersion: "/^v?0\\./",
       labels: ["type/major"],

--- a/labels.json5
+++ b/labels.json5
@@ -9,6 +9,14 @@
       matchUpdateTypes: ["minor"],
       labels: ["type/minor"],
     },
+    // Renovate classifies 0.x → 0.y as minor, but SemVer gives pre-1.0.0
+    // releases no stability guarantee, so label them as majors instead
+    // (later rules win, overriding the type/minor rule above).
+    {
+      matchUpdateTypes: ["minor"],
+      matchCurrentVersion: "/^v?0\\./",
+      labels: ["type/major"],
+    },
     {
       matchUpdateTypes: ["patch"],
       labels: ["type/patch"],

--- a/semanticCommits.json5
+++ b/semanticCommits.json5
@@ -12,6 +12,18 @@
       semanticCommitType: "feat",
       commitMessageExtra: "({{currentVersion}} → {{newVersion}})",
     },
+    // Renovate classifies 0.x → 0.y as minor, but SemVer gives pre-1.0.0
+    // releases no stability guarantee, so give them the major rule's breaking
+    // `!:` prefix. Must stay below the plain minor rule (later rules win) and
+    // above the CI/build tooling overrides at the bottom, which re-flatten the
+    // prefix so tooling bumps never release.
+    {
+      matchUpdateTypes: ["minor"],
+      matchCurrentVersion: "/^v?0\\./",
+      semanticCommitType: "feat",
+      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}})!:",
+      commitMessageExtra: "({{currentVersion}} → {{newVersion}})",
+    },
     {
       matchUpdateTypes: ["patch"],
       semanticCommitType: "fix",

--- a/semanticCommits.json5
+++ b/semanticCommits.json5
@@ -12,12 +12,10 @@
       semanticCommitType: "feat",
       commitMessageExtra: "({{currentVersion}} → {{newVersion}})",
     },
-    // Renovate classifies 0.x → 0.y as minor, but SemVer gives pre-1.0.0
-    // releases no stability guarantee, so give them the major rule's breaking
-    // `!:` prefix. Must stay below the plain minor rule (later rules win) and
-    // above the CI/build tooling overrides at the bottom, which re-flatten the
-    // prefix so tooling bumps never release.
+    // Keep below the plain minor rule and above the tooling overrides at the
+    // bottom, which re-flatten the prefix so tooling bumps never release.
     {
+      description: "zer0ver: 0.x minors can break at any time, give them the breaking `!` prefix",
       matchUpdateTypes: ["minor"],
       matchCurrentVersion: "/^v?0\\./",
       semanticCommitType: "feat",


### PR DESCRIPTION
Renovate classifies `0.x → 0.y` as a minor update, and the maintainers have [declined](https://github.com/renovatebot/renovate/discussions/30925) to change that classification. SemVer gives pre-1.0.0 releases no stability guarantee, so these bumps can break at any time while getting minor treatment from our presets.

This adds a `matchUpdateTypes: ["minor"]` + `matchCurrentVersion: "/^v?0\\./"` rule to each preset where update-type behavior lives:

- **labels.json5**: 0.x minors get `type/major` instead of `type/minor` (rule sits after the plain minor rule; later rules win per key).
- **semanticCommits.json5**: 0.x minors get the major rule's breaking `feat(scope)!:` prefix. The rule sits above the CI/build tooling overrides, so `github-actions`, `github-releases`, and `mise` bumps still get their flattened non-breaking prefix and never trigger release-please.
- **groups.json5**: 0.x minors get `additionalBranchPrefix: "major-"`, which lands them on the same `major-<groupSlug>` branch Renovate already uses to split grouped majors (the default `branchName` template is `{{branchPrefix}}{{additionalBranchPrefix}}{{branchTopic}}`). Breaking bumps like `talosctl-cluster-action` v0.1.6 → v0.2.1 no longer share a group PR with safe patches (see home-operations/tuppr#475); ungrouped 0.x minors just get a one-time `major-` branch rename.

Notes:

- The `v?` covers v-prefixed current versions (docker tags, github releases).
- Renovate still classifies these as minor internally, so branch names and the dependency dashboard keep saying minor; only labels and commit messages change.
- `0.0.x → 0.0.y` patches are left as patches; can follow up with the same pattern if we want that too.
- Repos that automerge by update type need a repo-local guard since repo rules concatenate after preset rules; kopiur is the only such repo and gets one in a separate PR.
