### PR TITLE
chore: automerge this repo's own non-major updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,4 +1,17 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
+  packageRules: [
+    {
+      description: "Auto-merge non-major updates, but only after every CI check passes",
+      matchUpdateTypes: ["minor", "patch", "digest", "lockFileMaintenance"],
+      automerge: true,
+    },
+    {
+      description: "zer0ver: 0.x minors can break at any time, don't automerge them",
+      matchUpdateTypes: ["minor"],
+      matchCurrentVersion: "/^v?0\\./",
+      automerge: false,
+    },
+  ],
 }


### PR DESCRIPTION
Nothing in the chain enabled automerge for this repo, so every dependency PR here waits on a manual merge; #70 says so in its own body ("Automerge: Disabled by config"). `default.json` extends `:automergePr`, which only picks the automerge *type*.

This turns it on in this repo's own `.renovaterc.json5` rather than in the shared preset, so the blast radius is this repo alone and consumers keep opting in themselves, the way kopiur, k8s-schemas and charts-mirror already do.

```json5
packageRules: [
  {
    description: "Auto-merge non-major updates, but only after every CI check passes",
    matchUpdateTypes: ["minor", "patch", "digest", "lockFileMaintenance"],
    automerge: true,
  },
  {
    description: "zer0ver: 0.x minors can break at any time, don't automerge them",
    matchUpdateTypes: ["minor"],
    matchCurrentVersion: "/^v?0\\./",
    automerge: false,
  },
]
```

Notes:

- `ignoreTests` stays at its default of `false`, so the `Build Success` gate still has to pass before anything merges.
- The mise tools and github-actions groups already carry `minimumReleaseAge: "3 days"`, so nothing lands the day it is tagged.
- The zer0ver carve-out keeps 0.x minors manual, matching the groups, labels and semanticCommits rules that already treat them as breaking.

Verified with `mise run lint` and `mise run validate default.json ./*.json5 .renovaterc.json5` (exit 0).