### PR TITLE
feat: never mark dependency updates as breaking

### DIFF
--- a/semanticCommits.json5
+++ b/semanticCommits.json5
@@ -1,10 +1,13 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
+    // No update type gets a breaking `!` prefix: breaking changes to a project
+    // must be user-authored. A dependency bump alone (even a major or a zer0ver
+    // 0.x minor) never breaks the project's own API surface, so release-please
+    // must never cut a breaking release from a Renovate commit.
     {
       matchUpdateTypes: ["major"],
       semanticCommitType: "feat",
-      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}})!:",
       commitMessageExtra: "({{currentVersion}} → {{newVersion}})",
     },
     {
@@ -12,14 +15,11 @@
       semanticCommitType: "feat",
       commitMessageExtra: "({{currentVersion}} → {{newVersion}})",
     },
-    // Keep below the plain minor rule and above the tooling overrides at the
-    // bottom, which re-flatten the prefix so tooling bumps never release.
     {
-      description: "zer0ver: 0.x minors can break at any time, give them the breaking `!` prefix",
+      description: "zer0ver: 0.x minors can break at any time; routed and reviewed like majors (see groups.json5), but committed as plain feat",
       matchUpdateTypes: ["minor"],
       matchCurrentVersion: "/^v?0\\./",
       semanticCommitType: "feat",
-      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}})!:",
       commitMessageExtra: "({{currentVersion}} → {{newVersion}})",
     },
     {
@@ -58,30 +58,41 @@
       commitMessageTopic: "dependency {{depName}}",
     },
     // github-actions, github-releases, and mise are CI/build tooling, not the
-    // released image/chart, so a major bump of them must not count as a breaking
-    // change: override the major-update `!:` prefix (set above) with a plain `:`,
-    // so release-please never cuts a version bump from a `ci!`/`chore!` tooling
-    // update (a `ci`/`chore` type is non-releasing on its own; only the `!` bumps).
+    // released image/chart, so they use the non-releasing `chore` type to keep
+    // tooling bumps out of release-please changelogs entirely.
     {
       matchManagers: ["github-actions"],
-      semanticCommitType: "ci",
+      semanticCommitType: "chore",
       semanticCommitScope: "github-action",
       commitMessageTopic: "action {{depName}}",
-      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}}):",
     },
     {
       matchDatasources: ["github-releases"],
       semanticCommitType: "chore",
       semanticCommitScope: "github-release",
       commitMessageTopic: "release {{depName}}",
-      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}}):",
     },
     {
       matchManagers: ["mise"],
       semanticCommitType: "chore",
       semanticCommitScope: "mise",
       commitMessageTopic: "tool {{depName}}",
-      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}}):",
+    },
+    // Test frameworks and lint/check-only tooling never reach the shipped
+    // artifact, so their bumps must not cut a release. Bundlers and compilers
+    // (svelte, vite, rollup, tailwind) stay releasing: they shape the artifact.
+    {
+      description: "Non-shipped dev tooling uses the non-releasing chore type",
+      matchDepNames: [
+        "github.com/onsi/ginkgo/v2",
+        "github.com/onsi/gomega",
+        "github.com/stretchr/testify",
+        "oxlint",
+        "svelte-check",
+        "@playwright/test",
+        "/^@types//",
+      ],
+      semanticCommitType: "chore",
     },
   ],
 }

--- a/semanticCommits.json5
+++ b/semanticCommits.json5
@@ -1,10 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
-    // No update type gets a breaking `!` prefix: breaking changes to a project
-    // must be user-authored. A dependency bump alone (even a major or a zer0ver
-    // 0.x minor) never breaks the project's own API surface, so release-please
-    // must never cut a breaking release from a Renovate commit.
     {
       matchUpdateTypes: ["major"],
       semanticCommitType: "feat",
@@ -16,7 +12,6 @@
       commitMessageExtra: "({{currentVersion}} → {{newVersion}})",
     },
     {
-      description: "zer0ver: 0.x minors can break at any time; routed and reviewed like majors (see groups.json5), but committed as plain feat",
       matchUpdateTypes: ["minor"],
       matchCurrentVersion: "/^v?0\\./",
       semanticCommitType: "feat",
@@ -57,9 +52,6 @@
       semanticCommitScope: "npm",
       commitMessageTopic: "dependency {{depName}}",
     },
-    // github-actions, github-releases, and mise are CI/build tooling, not the
-    // released image/chart, so they use the non-releasing `chore` type to keep
-    // tooling bumps out of release-please changelogs entirely.
     {
       matchManagers: ["github-actions"],
       semanticCommitType: "chore",
@@ -77,22 +69,6 @@
       semanticCommitType: "chore",
       semanticCommitScope: "mise",
       commitMessageTopic: "tool {{depName}}",
-    },
-    // Test frameworks and lint/check-only tooling never reach the shipped
-    // artifact, so their bumps must not cut a release. Bundlers and compilers
-    // (svelte, vite, rollup, tailwind) stay releasing: they shape the artifact.
-    {
-      description: "Non-shipped dev tooling uses the non-releasing chore type",
-      matchDepNames: [
-        "github.com/onsi/ginkgo/v2",
-        "github.com/onsi/gomega",
-        "github.com/stretchr/testify",
-        "oxlint",
-        "svelte-check",
-        "@playwright/test",
-        "/^@types//",
-      ],
-      semanticCommitType: "chore",
     },
   ],
 }


### PR DESCRIPTION
## What

Removes the breaking `!` prefix from Renovate's commit messages for major updates and zer0ver 0.x minors. The zer0ver rule itself stays as in-place documentation of the routing policy, just without the breaking prefix. The CI/tooling rules lose their now-redundant prefix overrides, and github-actions moves from `ci` to `chore` so all tooling bumps share one non-releasing type.

Also relabels non-shipped dev tooling as `chore`: test frameworks (ginkgo, gomega, testify) and lint/check-only npm tooling (oxlint, svelte-check, @playwright/test, @types/*) never reach the shipped artifact, so their bumps no longer cut releases. Bundlers and compilers (svelte, vite, rollup, tailwind) intentionally stay releasing since they shape the built artifact, as do go directive bumps (a new Go patch recompiles the binary with stdlib fixes).

## Why

Breaking changes to a project should only ever be user-authored. A dependency bump alone - even a major, or a 0.x minor that zer0ver treats as one - does not change the project's own API surface, so release-please should never cut a breaking release from a Renovate commit. Since no rule sets `!` anymore, a `chore!` commit (which would still bump a major) can no longer be produced by Renovate.

Examples of current behavior this stops: home-operations/konflate#436, where the pending 0.6.0 release grew a "⚠ BREAKING CHANGES" section solely because Renovate bumped `flate` v0.4.14 → v0.5.0 with a `feat(go)!:` prefix (home-operations/konflate#433); tuppr/miroir/litellm-operator cutting patch releases for ginkgo (test-only) bumps.

Reverts the prefix half of #64. Unaffected: the zer0ver major-branch routing in `groups.json5` and per-repo automerge guards (e.g. home-operations/kopiur#352) stay in place - 0.x minors still get individual, non-automerged PRs; they just no longer flag the release as breaking.