### PR TITLE
feat: stop updating the go.mod go directive

### DIFF
--- a/groups.json5
+++ b/groups.json5
@@ -23,25 +23,24 @@
     },
     {
       description: "Go Toolchain Group",
-      matchManagers: ["mise", "gomod"],
+      matchManagers: ["mise"],
       matchDepNames: ["go"],
-      matchFileNames: [".mise/config.toml", "go.mod"],
+      matchFileNames: [".mise/config.toml"],
       groupName: "Go toolchain",
       groupSlug: "go-toolchain",
     },
     {
-      // The go directive defaults to Renovate's go-mod-directive versioning,
-      // which reads `go 1.26.4` as a minimum satisfied by any later 1.26.x —
-      // so Renovate proposes directive updates only on new minors and the
-      // directive drifts behind the mise-pinned toolchain on every patch
-      // (the fleet sat at 1.26.0–1.26.4 while mise was on 1.26.5). Semver
-      // versioning makes patches count as updates; the group above then
-      // lands the directive bump in the same PR as the mise pin.
-      description: "Track Go patch releases in go.mod's go directive",
+      // The go directive is a compatibility floor, not the build toolchain —
+      // the mise pin above is what actually compiles and tests. Fleet policy:
+      // the directive stays pinned at the lowest release of the supported
+      // minor (currently 1.26.0) and only the mise pin moves, so a gap
+      // between the two is expected. Raise the directive by hand when the
+      // code needs a newer Go version.
+      description: "Never update go.mod's go directive; it is pinned manually",
       matchManagers: ["gomod"],
       matchDepNames: ["go"],
       matchDepTypes: ["golang"],
-      versioning: "semver",
+      enabled: false,
     },
     {
       description: "Rust Toolchain Group",

--- a/groups.json5
+++ b/groups.json5
@@ -30,19 +30,6 @@
       groupSlug: "go-toolchain",
     },
     {
-      // The go directive is a compatibility floor, not the build toolchain —
-      // the mise pin above is what actually compiles and tests. Fleet policy:
-      // the directive stays pinned at the lowest release of the supported
-      // minor (currently 1.26.0) and only the mise pin moves, so a gap
-      // between the two is expected. Raise the directive by hand when the
-      // code needs a newer Go version.
-      description: "Never update go.mod's go directive; it is pinned manually",
-      matchManagers: ["gomod"],
-      matchDepNames: ["go"],
-      matchDepTypes: ["golang"],
-      enabled: false,
-    },
-    {
       description: "Rust Toolchain Group",
       matchManagers: ["mise"],
       matchDepNames: ["rust"],


### PR DESCRIPTION
The go directive is a compatibility floor, not the build toolchain; the mise pin is what actually compiles and tests. New fleet policy: pin the directive at the lowest release of the supported minor (currently `1.26.0`) and let only the mise pin move.

This replaces the semver-versioning override from #61 (which made the directive track patch releases alongside the mise pin) with `enabled: false` for the gomod `go` dep, and drops `gomod`/`go.mod` from the Go Toolchain Group since the group now only carries the mise pin. Future directive bumps (e.g. to 1.27) are manual.

Companion PRs pin the directive to `1.26.0` in each Go repo.