### PR TITLE
feat(presets): automerge self-gating dev tooling and first-party actions

### DIFF
--- a/autoMerge.json5
+++ b/autoMerge.json5
@@ -14,6 +14,7 @@
       matchDepNames: [
         "actionlint",
         "aqua:dadav/helm-schema",
+        "gh",
         "lefthook",
         "oxfmt",
         "shellcheck",

--- a/autoMerge.json5
+++ b/autoMerge.json5
@@ -1,0 +1,48 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    // Automerge is reserved for tools whose breakage is caught by the checks
+    // on the bump PR itself, or whose blast radius ends at a dev machine.
+    // Tools that only run in release workflows (cosign, goreleaser, builder
+    // and login actions) stay manual: a bad bump there merges green and only
+    // surfaces at the next tag. Majors stay manual everywhere; note that
+    // zer0ver 0.x minors still automerge — for these tools the formatting or
+    // lint drift they can cause fails their own PR, which is the gate.
+    {
+      description: "Dev tooling (mise): formatters, linters, and hook runners with no runtime or release blast radius",
+      matchManagers: ["mise"],
+      matchDepNames: [
+        "actionlint",
+        "aqua:dadav/helm-schema",
+        "lefthook",
+        "oxfmt",
+        "shellcheck",
+        "yq",
+        "zizmor",
+      ],
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+    },
+    {
+      description: "helm-unittest: test-only helm plugin, gated by the chart tests on its own bump PR",
+      matchDatasources: ["github-releases"],
+      matchDepNames: ["helm-unittest/helm-unittest"],
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+    },
+    {
+      description: "oxlint (npm): lint-only, gated by the lint job on its own bump PR",
+      matchManagers: ["npm"],
+      matchDepNames: ["oxlint"],
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+    },
+    {
+      description: "First-party actions and reusable workflows",
+      matchManagers: ["github-actions"],
+      matchDepNames: ["home-operations/**"],
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      automerge: true,
+    },
+  ],
+}

--- a/autoMerge.json5
+++ b/autoMerge.json5
@@ -2,7 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
     {
-      description: "Auto-merge dev tools",
+      description: "Auto-merge devtools",
       matchManagers: ["mise"],
       matchDepNames: [
         "actionlint",

--- a/autoMerge.json5
+++ b/autoMerge.json5
@@ -1,15 +1,8 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
-    // Automerge is reserved for tools whose breakage is caught by the checks
-    // on the bump PR itself, or whose blast radius ends at a dev machine.
-    // Tools that only run in release workflows (cosign, goreleaser, builder
-    // and login actions) stay manual: a bad bump there merges green and only
-    // surfaces at the next tag. Majors stay manual everywhere; note that
-    // zer0ver 0.x minors still automerge — for these tools the formatting or
-    // lint drift they can cause fails their own PR, which is the gate.
     {
-      description: "Dev tooling (mise): formatters, linters, and hook runners with no runtime or release blast radius",
+      description: "Auto-merge dev tools",
       matchManagers: ["mise"],
       matchDepNames: [
         "actionlint",
@@ -25,36 +18,17 @@
       automerge: true,
     },
     {
-      description: "helm-unittest: test-only helm plugin, gated by the chart tests on its own bump PR",
+      description: "Auto-merge helm-unittest",
       matchDatasources: ["github-releases"],
       matchDepNames: ["helm-unittest/helm-unittest"],
       matchUpdateTypes: ["minor", "patch"],
       automerge: true,
     },
     {
-      description: "oxlint (npm): lint-only, gated by the lint job on its own bump PR",
+      description: "Auto-merge oxlint",
       matchManagers: ["npm"],
       matchDepNames: ["oxlint"],
       matchUpdateTypes: ["minor", "patch"],
-      automerge: true,
-    },
-    {
-      description: "First-party standalone actions (github-actions manager)",
-      matchManagers: ["github-actions"],
-      matchDepNames: ["home-operations/**"],
-      matchUpdateTypes: ["minor", "patch", "digest"],
-      automerge: true,
-    },
-    // The shared .github actions are pinned via the custom manager in
-    // sharedActions.json5, not the github-actions manager. Its depNameTemplate
-    // is the only source of this depName shape, so the pattern alone cannot
-    // catch other custom.regex deps (annotated vendir/release bumps of
-    // first-party projects are runtime changes and must stay manual).
-    {
-      description: "First-party shared actions (sharedActions.json5 custom manager)",
-      matchManagers: ["custom.regex"],
-      matchDepNames: ["home-operations/.github/actions/**"],
-      matchUpdateTypes: ["minor", "patch", "digest"],
       automerge: true,
     },
   ],

--- a/autoMerge.json5
+++ b/autoMerge.json5
@@ -38,9 +38,21 @@
       automerge: true,
     },
     {
-      description: "First-party actions and reusable workflows",
+      description: "First-party standalone actions (github-actions manager)",
       matchManagers: ["github-actions"],
       matchDepNames: ["home-operations/**"],
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      automerge: true,
+    },
+    // The shared .github actions are pinned via the custom manager in
+    // sharedActions.json5, not the github-actions manager. Its depNameTemplate
+    // is the only source of this depName shape, so the pattern alone cannot
+    // catch other custom.regex deps (annotated vendir/release bumps of
+    // first-party projects are runtime changes and must stay manual).
+    {
+      description: "First-party shared actions (sharedActions.json5 custom manager)",
+      matchManagers: ["custom.regex"],
+      matchDepNames: ["home-operations/.github/actions/**"],
       matchUpdateTypes: ["minor", "patch", "digest"],
       automerge: true,
     },

--- a/default.json
+++ b/default.json
@@ -6,6 +6,7 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "abandonments:recommended",
     "github>home-operations/renovate-config:annotated.json5",
+    "github>home-operations/renovate-config:autoMerge.json5",
     "github>home-operations/renovate-config:groups.json5",
     "github>home-operations/renovate-config:helmPostUpgradeTasks.json5",
     "github>home-operations/renovate-config:labels.json5",


### PR DESCRIPTION
## What

Adds an `autoMerge.json5` preset (wired into `default.json`) that automerges minor/patch updates for dependencies whose breakage is caught by the checks on the bump PR itself, or whose blast radius ends at a dev machine:

- **mise dev tools**: `oxfmt`, `zizmor`, `lefthook`, `actionlint`, `shellcheck`, `yq`, `gh`, `aqua:dadav/helm-schema`
- **helm-unittest** (annotated github-releases dep): gated by the chart tests on its own PR
- **oxlint** (npm): gated by the lint job on its own PR

First-party actions (`home-operations/**`) were considered but dropped from scope; they stay manual.

## Why

Over the last 93 days these deps accounted for a large share of all merged Renovate PRs org-wide, none of which benefit from review:

| dep | merged PRs / 93d | repos |
|---|---|---|
| oxfmt | 236 | 23 |
| zizmor | 79 | 23 |
| lefthook | 23 | 19 |
| yq | 19 | 15 |
| helm-unittest | 15 | 11 |

The selection criterion is deliberately narrow: a breaking release of any listed tool fails the lint/test checks on its own bump PR and simply doesn't automerge. Tools that only run in release workflows (`cosign`, builder/login actions), language toolchains, and `npm:renovate` itself are intentionally **not** included - a bad bump there merges green and only surfaces at the next tag or bot run.

## Notes

- zer0ver 0.x minors (oxfmt) still automerge: the existing routing/labeling rules set different keys, so they coexist - the PR is labeled and branched as a major but merges itself once checks pass. For these tools the CI gate is the review.
- Majors stay manual everywhere.
- The 3-day `minimumReleaseAge` on the mise group continues to apply, so this doesn't change exposure to fresh releases.
- Grouped "mise tools" PRs automerge only when every update in the branch matches a listed dep.

